### PR TITLE
replace ansible with a very small shell script

### DIFF
--- a/ooni-sysadmin-ng/install-common.sh
+++ b/ooni-sysadmin-ng/install-common.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+# exit on unset variable or non-0 return code.
+set -eu
+
+# apt-get install -y assume yes
+
+apt-get update
+apt-get dist-upgrade -y
+apt-get install -y sudo tor
+
+wget "https://bootstrap.pypa.io/get-pip.py"
+python get-pip.py
+# update-alternatives?
+
+apt-get install -y build-essential python-dev python-setuptools
+apt-get install -y openssl libssl-dev libyaml-dev libsqlite3-dev libffi-dev

--- a/ooni-sysadmin-ng/install-ooni-backend.sh
+++ b/ooni-sysadmin-ng/install-ooni-backend.sh
@@ -1,0 +1,87 @@
+#!/bin/sh
+
+# exit on unset variable or non-0 return code.
+set -eu
+
+sh install-common.sh
+pip install oonibackend
+
+# we export these variables to pass them to the oonibackend.conf.sh and
+# oonibackend.service.sh templates.
+export oonib_bin=$(which oonib)
+
+# directories owned by and daemon running as this user.
+# --system means no login and no shell.
+export oonib_user="oonib"
+adduser --system --no-create-home --quiet $oonib_user
+
+export dns_resolver_address="8.8.8.8:53"
+
+# some of these features can be disabled with a value of "null".
+export http_return_json_headers_port="57001"
+export tcp_echo_port="57002"
+export daphn3_port="57003"
+export dns_port_tcp="57004"
+export dns_port_udp="57004"
+export dns_discover_port_tcp="57005"
+export dns_discover_port_udp="57005"
+export ssl_port="57006"
+
+export log_dir="/var/log/ooni"
+export deck_dir="/usr/share/ooni/backend/decks"
+export input_dir="/usr/share/ooni/backend/inputs"
+
+export tor_datadir="/var/spool/ooni/backend/tor"
+export archive_dir="/var/spool/ooni/backend/archive"
+export report_dir="/var/spool/ooni/backend/raw_reports"
+
+export policy_file="/var/spool/ooni/backend/policy.yaml"
+export bouncer_file="/var/spool/ooni/backend/bouncer.yaml"
+
+export ssl_dir="/etc/oonib/ssl"
+export ssl_key=$ssl_dir"/key.pem"
+export ssl_cert=$ssl_dir"/cert.pem"
+
+for dir in "
+$log_dir \
+$deck_dir \
+$input_dir \
+$tor_datadir \
+$archive_dir \
+$report_dir \
+$ssl_dir \
+"; do
+    mkdir -p $dir
+    chown $oonib_user $dir
+done
+
+# stick some environment variables in the templates and copy them into place
+sh oonibackend.conf.sh
+cp oonibackend.conf /etc/
+
+sh oonibackend.service.sh
+cp oonibackend.service /lib/systemd/system/
+
+# make self-signed cert for https tests
+openssl req -x509 -newkey rsa:4096 \
+    -keyout $ssl_key -out $ssl_cert \
+    -days 400 -nodes -subj '/CN=selfie'
+chown $oonib_user $ssl_dir/*
+chmod 0600 $ssl_dir/*
+
+# map http, ssl, dns ports so they're at the normal places on the outside
+iptables -t nat -A PREROUTING -p tcp -m tcp \
+    --dport 80 -j REDIRECT --to-ports $http_return_json_headers_port
+
+iptables -t nat -A PREROUTING -p tcp -m tcp \
+    --dport 443 -j REDIRECT --to-ports $ssl_port
+
+#iptables -t nat -A PREROUTING -p tcp -m udp \
+#    --dport 53 -j REDIRECT --to-ports $dns_port_udp
+#
+#iptables -t nat -A PREROUTING -p tcp -m tcp \
+#    --dport 53 -j REDIRECT --to-ports $dns_port_tcp
+
+# enable and start the service
+systemctl enable oonibackend.service
+systemctl start oonibackend.service

--- a/ooni-sysadmin-ng/oonibackend.conf.sh
+++ b/ooni-sysadmin-ng/oonibackend.conf.sh
@@ -1,0 +1,66 @@
+#!/bin/sh
+
+# this script expects to be run by install-ooni-backend.sh which creates
+# users, directories, sets owners, keeps things in once place, etc.
+# exit on unset variable or non-0 return code.
+set -eu
+
+cat > oonibackend.conf <<EOF
+helpers:
+  daphn3:
+    address: null
+    pcap_file: null
+    port: $daphn3_port
+    yaml_file: null
+  dns:
+    address: null
+    resolver_address: $dns_resolver_address
+    tcp_port: $dns_port_tcp
+    udp_port: $dns_port_udp
+  dns_discovery:
+    address: null
+    resolver_address: null
+    tcp_port: $dns_discover_port_tcp
+    udp_port: $dns_discover_port_udp
+  http-return-json-headers:
+    address: null
+    port: $http_return_json_headers_port
+    server_version: Apache
+  ssl:
+    address: null
+    certificate: $ssl_cert
+    private_key: $ssl_key
+    port: $ssl_port
+  tcp-echo:
+    address: null
+    port: $tcp_echo_port
+main:
+  archive_dir: $archive_dir
+  bouncer_file: $bouncer_file
+  chroot: null
+  database_uri: sqlite://oonib_test_db.db
+  db_threadpool_size: 10
+  debug: false
+  deck_dir: $deck_dir
+  euid: null
+  gid: null
+  input_dir: $input_dir
+  logfile: $log_dir/oonibackend.log
+  no_save: true
+  nodaemon: true
+  originalname: null
+  pidfile: null
+  policy_file: $policy_file
+  profile: null
+  report_dir: $report_dir
+  rundir: .
+  socks_port: 9055
+  stale_time: 3600
+  tor2webmode: false
+  tor_binary: null
+  tor_datadir: $tor_datadir
+  tor_hidden_service: true
+  uid: null
+  umask: null
+  uuid: null
+EOF

--- a/ooni-sysadmin-ng/oonibackend.service.sh
+++ b/ooni-sysadmin-ng/oonibackend.service.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+# exit on unset variable or non-0 return code.
+set -eu
+
+cat > oonibackend.service <<EOF
+[Unit]
+Description=oonibackend
+
+[Service]
+User=$oonib_user
+Restart=always
+ExecStart=$oonib_bin -c /etc/oonibackend.conf
+
+[Install]
+WantedBy=multi-user.target
+EOF


### PR DESCRIPTION
`sudo sh install-ooni-backend.sh` on a fresh debian jessie ec2 instance gets `oonib` running as a service under systemd.

(some things i should polish, but i just tested it on a new instance and it works)