### PR TITLE
Fix check set_ooniprobe_pip is defined before

### DIFF
--- a/ansible/roles/ooniprobe/tasks/main.yml
+++ b/ansible/roles/ooniprobe/tasks/main.yml
@@ -2,5 +2,5 @@
 - include: install.yml
   when: set_ooniprobe_pip is not defined
 - include: install-git.yml
-  when: set_ooniprobe_pip == 'true'
+  when: set_ooniprobe_pip is defined and set_ooniprobe_pip == 'true'
 - include: cron.yml


### PR DESCRIPTION
Fix check set_ooniprobe_pip is defined before checking if it is equal
to true. https://github.com/TheTorProject/ooni-sysadmin/issues/21
As spotted by @elationfoundation