### PR TITLE
Install ooniprobe from git (master)

### DIFF
--- a/ansible/roles/ooniprobe/tasks/install-git.yml
+++ b/ansible/roles/ooniprobe/tasks/install-git.yml
@@ -34,4 +34,4 @@
     name={{ item }}
   with_items:
     - cffi
-    - ooniprobe
+    - 'git+https://github.com/TheTorProject/ooni-probe.git#egg=ooniprobe'


### PR DESCRIPTION
Git install should better install from git master the latest ooniprobe
version that includes all pluggable transports tests and potential fixes