### PR TITLE
Ansible third party tools role

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,23 @@ Wheesy and Jessie Debian releases. By seting the conditional variable
 ansible-playbook -i "hosts-inventory" ansible/install-ooniprobe.yml -v
 ```
 
+## Third party tools
+
+This ansible role install third party tools required for some ooniprobe
+tests. The following third party tools can be installed with this role:
+
+Tool|oooniprobe test
+----|---------------
+OpenVPN|https://github.com/TheTorProject/ooni-spec/blob/master/test-specs/ts-015-openvpn.md
+Psiphon|https://github.com/TheTorProject/ooni-spec/blob/master/test-specs/ts-014-psiphon.md
+Lantern|https://github.com/TheTorProject/ooni-spec/blob/master/test-specs/ts-012-lantern.md
+
+### execute role
+
+```
+ansible-playbook -i "hosts-inventory" ansible/install-thirdparty.yml -v
+```
+
 # Instructions
 
 Unless otherwise indicated the instructions are for debian wheezy.

--- a/ansible/install-thirdparty.yml
+++ b/ansible/install-thirdparty.yml
@@ -1,0 +1,5 @@
+---
+- hosts: local:custom
+  roles:
+  - common
+  - third-party

--- a/ansible/roles/third-party/tasks/install-lantern.yml
+++ b/ansible/roles/third-party/tasks/install-lantern.yml
@@ -1,0 +1,18 @@
+---
+- name: Get lantern x86_64 deb package
+  get_url: >
+    url=https://raw.githubusercontent.com/getlantern/lantern-binaries/master/lantern-installer-beta-64-bit.deb
+    dest={{ ansible_env.HOME }}/lantern-installer.deb
+  when: ansible_architecture == "x86_64"
+
+- name: Get lantern i386 deb package
+  get_url: >
+    url=https://raw.githubusercontent.com/getlantern/lantern-binaries/master/lantern-installer-beta-32-bit.deb
+    dest={{ ansible_env.HOME }}/lantern-installer.deb
+  when: ansible_architecture == "i386"
+
+- name: Install lantern package dependencies
+  apt: name=libappindicator3-1
+
+- name: Install lantern deb package
+  apt: deb="{{ ansible_env.HOME }}/lantern-installer.deb"

--- a/ansible/roles/third-party/tasks/install-openvpn.yml
+++ b/ansible/roles/third-party/tasks/install-openvpn.yml
@@ -1,0 +1,6 @@
+---
+- name: Install OpenVPN package
+  apt: >
+    update_cache=yes
+    state=latest
+    name=openvpn

--- a/ansible/roles/third-party/tasks/install-psiphon.yml
+++ b/ansible/roles/third-party/tasks/install-psiphon.yml
@@ -1,0 +1,35 @@
+---
+- name: Create {{ PSIPHON_PYCLIENT_PATH }}
+  file: >
+    path={{ PSIPHON_PYCLIENT_PATH }}
+    state=directory
+
+- name: Install mercurial package
+  apt: name=mercurial
+
+- name: Clone Psiphon mercurial repository
+  hg: >
+    repo=https://bitbucket.org/psiphon/psiphon-circumvention-system
+    dest={{ PSIPHON_PYCLIENT_PATH }}
+
+- name: Install pip Psiphon requirements
+  pip: >
+    name={{ item }}
+  with_items:
+    - wget
+    - jsonpickle
+    - pexpect
+
+- name: Copy psi_generate_dat.py
+  template: >
+    src=psi_generate_dat.py.j2
+    dest=/tmp/psi_generate_dat.py
+    mode=0755
+
+- name: Run psi_generate_dat.py to create Psiphon servers data file
+  command: /tmp/psi_generate_dat.py
+  args:
+    chdir: /tmp/
+
+- name: Move file to {{ PSIPHON_PYCLIENT_PATH }}
+  command: mv /tmp/psi_client.dat "{{ PSIPHON_PYCLIENT_PATH  }}"

--- a/ansible/roles/third-party/tasks/main.yml
+++ b/ansible/roles/third-party/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+- include: install-openvpn.yml
+- include: install-psiphon.yml
+- include: install-lantern.yml

--- a/ansible/roles/third-party/templates/psi_generate_dat.py.j2
+++ b/ansible/roles/third-party/templates/psi_generate_dat.py.j2
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+
+import wget
+import os
+import json
+
+# Delete 'server_list' if exists
+if os.path.exists("server_list"):
+   # os.remove("server_list")
+    # os.rename("server_list", "server_list")
+    pass
+else:
+    # Download 'server_list'
+    url ="https://psiphon3.com/server_list"
+    wget.download(url)
+
+# convert server_list to psi_client.dat
+dat = {}
+dat["propagation_channel_id"] = "FFFFFFFFFFFFFFFF"
+dat["sponsor_id"] = "FFFFFFFFFFFFFFFF"
+dat["servers"] = json.load(open('server_list'))['data'].split()
+json.dump(dat, open('psi_client.dat', 'w'))

--- a/ansible/roles/third-party/vars/main.yml
+++ b/ansible/roles/third-party/vars/main.yml
@@ -1,0 +1,2 @@
+---
+PSIPHON_PYCLIENT_PATH: "{{ ansible_env.HOME }}/psiphon-circumvention-system/pyclient"


### PR DESCRIPTION
This ansible roles installs the third party
tools required for some ooniprobe tests.
* Add Lantern installation task
* Add Psiphon installation task
* Add OpenVPN installation task
* Add ansible role documentation