### PR TITLE
Fix tor repo release name variables

### DIFF
--- a/ansible/roles/common/tasks/tor.yml
+++ b/ansible/roles/common/tasks/tor.yml
@@ -7,13 +7,13 @@
 
 - name: setup tor apt repo
   apt_repository: >
-    repo='deb http://deb.torproject.org/torproject.org {{ tor_distribution_release }} main'
+    repo='deb http://deb.torproject.org/torproject.org {{ ansible_distribution_release }} main'
     state=present 
     update_cache=yes
 
 - name: setup tor apt repo
   apt_repository: >
-    repo='deb http://deb.torproject.org/torproject.org {{ tor_distribution_release_experimental }} main'
+    repo='deb http://deb.torproject.org/torproject.org {{ ansible_distribution_release }}-{{ tor-version }} main'
     state=present 
     update_cache=yes
   when: experimental_tor == "yes"

--- a/ansible/roles/common/vars/main.yml
+++ b/ansible/roles/common/vars/main.yml
@@ -1,1 +1,2 @@
 experimental_tor: no
+tor-version: 0.2.7.x


### PR DESCRIPTION
Fix to correct repo name taken from ansible variable.
Add tor-version for the experimental repo.
As spotted by @elationfoundation
https://github.com/TheTorProject/ooni-sysadmin/issues/23