### PR TITLE
Change installation of obfsproxy via pip

### DIFF
--- a/ansible/roles/tor-pluggable-trans/tasks/install-obfsproxy.yml
+++ b/ansible/roles/tor-pluggable-trans/tasks/install-obfsproxy.yml
@@ -1,3 +1,3 @@
 ---
-- name: Install obfsproxy (obfs2, obfs3, scramblesuit)
-  apt: name=obfsproxy
+- name: Install obfsproxy (obfs2, obfs3, scramblesuit) via pip
+  pip: name=obfsproxy


### PR DESCRIPTION
obfsproxy package requires dependencies that have
been already installed via pip