### PR TITLE
Change the order of executed roles in common

### DIFF
--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - include: base.yml
+- include: python-dev.yml
 - include: pip.yml
   when: ansible_distribution == 'Debian'
         and ansible_distribution_major_version|int <= 7
 - include: tor.yml
-- include: python-dev.yml


### PR DESCRIPTION
The playbook should install the the python-dev role and then run
conditionally the pip update otherwise it may just end up having the
version of pip overridden by the debian package one.
As spotted by @hellais