### PR TITLE
Change OS release to jessie, reduce dependencies

### DIFF
--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -1,12 +1,7 @@
-FROM debian:wheezy
+FROM debian:jessie
 MAINTAINER Arturo Filastò <art@torproject.org>
 RUN apt-get -y update
-RUN apt-get install -y python-yaml python-jinja2 git
-RUN git clone https://github.com/ansible/ansible.git /tmp/ansible
-WORKDIR /tmp/ansible
-ENV PATH /tmp/ansible/bin:/sbin:/usr/sbin:/usr/bin:/bin/:/usr/local/bin
-ENV ANSIBLE_LIBRARY /tmp/ansible/library
-ENV PYTHONPATH /tmp/ansible/lib:$PYTHON_PATH
+RUN apt-get install -y git-core ansible
 RUN git clone https://github.com/TheTorProject/ooni-sysadmin.git /tmp/ooni-sysadmin
 ADD inventory /etc/ansible/hosts
 WORKDIR /tmp/ooni-sysadmin/

--- a/docker/bouncer/Dockerfile
+++ b/docker/bouncer/Dockerfile
@@ -1,9 +1,7 @@
-FROM debian:wheezy
+FROM debian:jessie
 MAINTAINER Arturo Filastò <art@torproject.org>
 RUN apt-get -y update
-RUN apt-get install -y python-pip python-dev git
-RUN pip install PyYAML jinja2 paramiko
-RUN pip install ansible==1.7.1
+RUN apt-get install -y git-core ansible
 RUN git clone https://github.com/TheTorProject/ooni-sysadmin.git /tmp/ooni-sysadmin
 ADD inventory /etc/ansible/hosts
 WORKDIR /tmp/ooni-sysadmin/

--- a/docker/probe/Dockerfile
+++ b/docker/probe/Dockerfile
@@ -1,8 +1,7 @@
-FROM debian:wheezy
+FROM debian:jessie
 MAINTAINER Arturo Filastò <art@torproject.org>
 RUN apt-get -y update
-RUN apt-get install -y python-pip python-dev git
-RUN pip install ansible==1.7.1
+RUN apt-get install -y git-core ansible
 ADD http://www.random.org/strings/?num=10&len=8&digits=on&upperalpha=on&loweralpha=on&unique=on&format=plain&rnd=new uuid
 RUN git clone https://github.com/TheTorProject/ooni-sysadmin.git /tmp/ooni-sysadmin
 WORKDIR /tmp/ooni-sysadmin/


### PR DESCRIPTION
Use Debian Jessie release to build the docker image.
Install ansible from apt packages since Debian Jessie release includes
an updated ansible package helping to reduce dependencies on the Docker
build file. Replace git package by git-core.