### PR TITLE
Do not run backend in supervisord for docker image

### DIFF
--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -7,5 +7,7 @@ ADD inventory /etc/ansible/hosts
 WORKDIR /tmp/ooni-sysadmin/
 RUN git submodule update --init
 WORKDIR /tmp/ooni-sysadmin/ansible
-RUN ansible-playbook -v install-oonibackend.yml -c local --extra-vars "archive_dir=/data/archive tor_datadir=/data/tor"
+#RUN ansible-playbook -v install-oonibackend.yml -c local --extra-vars "archive_dir=/data/archive tor_datadir=/data/tor"
+RUN ansible-playbook -v install-oonibackend.yml -c local --extra-vars \
+	"archive_dir=/data/archive tor_datadir=/data/tor set_supervisord='false'"
 CMD ["/usr/local/bin/oonib", "-c", "/etc/oonibackend.conf"]


### PR DESCRIPTION
This change disables running ooni-backend in supervisod in docker build
image.