### PR TITLE
Add docker-py version requirement, set state,restart policy

### DIFF
--- a/ansible/roles/docker_py/tasks/main.yml
+++ b/ansible/roles/docker_py/tasks/main.yml
@@ -2,5 +2,5 @@
 - name: Install docker-py via pip in virtualenv
   pip: >
     name="docker-py"
-    version="1.2.1"
+    version="1.7.0"
     virtualenv="{{ ansible_env.HOME }}/venv"

--- a/ansible/roles/ooni-backend/tasks/docker_deploy.yml
+++ b/ansible/roles/ooni-backend/tasks/docker_deploy.yml
@@ -22,7 +22,7 @@
 
 - name: Build docker image
   docker_image: >
-    state=build
+    state=present
     timeout=1500
     name="{{ docker_img_name }}"
     path="{{ bind_oonibackend_data_path }}"
@@ -53,3 +53,4 @@
     - "{{ bind_oonibackend_log_path }}:{{ oonibackend_log_path }}"
     - "{{ bind_oonibackend_conf_path }}:{{ oonibackend_conf_path }}"
     - "{{ bind_oonibackend_data_path }}:{{ oonibackend_data_path }}"
+    restart_policy: always


### PR DESCRIPTION
Ansible docker_py module has deprecated the build state and bumped the
docker-py dependency to >= 1.7.0. Adding latest to the version doesn't
work as expected as the docker_py is not correctly validating the
version number.

The module option 'build' in state is deprecated and will now behave the
same as the 'present' option.

Set the docker container policy to always, to restart stopped containers