### PR TITLE
fix,refactor(proteus-events): topics correctness

### DIFF
--- a/ansible/deploy-proteus-events.yml
+++ b/ansible/deploy-proteus-events.yml
@@ -7,6 +7,7 @@
     proteus_auth_jwt_secret : "{{ vault_proteus_auth_jwt_secret_testing }}"
     proteus_notify_url: "https://notify.proteus.test.ooni.io"
     proteus_notify_basic_auth_password: "{{ vault_proteus_notify_basic_auth_password_testing }}"
+    proteus_notify_topic_ios: "org.openobservatory.NetProbe"
   roles:
     - letsencrypt
     - proteus-events
@@ -20,6 +21,7 @@
     proteus_auth_jwt_secret : "{{ vault_proteus_auth_jwt_secret }}"
     proteus_notify_url: "https://notify.proteus.ooni.io"
     proteus_notify_basic_auth_password: "{{ vault_proteus_notify_basic_auth_password }}"
+    proteus_notify_topic_ios: "org.openobservatory.NetProbe"
   roles:
     - letsencrypt
     - proteus-events

--- a/ansible/roles/proteus-events/templates/proteus-events.toml.j2
+++ b/ansible/roles/proteus-events/templates/proteus-events.toml.j2
@@ -2,8 +2,7 @@
 environment = "{{ proteus_environment }}"
 log-level = "{{ proteus_log_level }}"
 gorush-url = "{{ proteus_notify_url }}"
-notify-topic-ios = "org.openobservatory.NetProbe"
-notify-topic-android = "org.openobservatory.NetProbe"
+notify-topic-ios = "{{ proteus_notify_topic_ios }}"
 
 [auth]
 jwt-secret = "{{ proteus_auth_jwt_secret }}"


### PR DESCRIPTION
1) As stated in TheTorProject/proteus#13, we must not set a topic
for Android because that leads to FCM rejecting the message.

2) Define two different topics for iOS, one for production and
one for testing, because I guess we'll need them soon.