### PR TITLE
feature(roles/adm): ssh -= {pwd-based-auth, root-login}

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 logging.cfg
 *.log
 invoke.yaml
@@ -6,3 +7,4 @@ invoke.yaml
 *.swo
 backend-files/
 secrets.env.j2
+/venv

--- a/ansible/roles/adm/handlers/main.yml
+++ b/ansible/roles/adm/handlers/main.yml
@@ -1,0 +1,3 @@
+---
+- name: Restart ssh
+  service: name=ssh state=restarted

--- a/ansible/roles/adm/tasks/main.yml
+++ b/ansible/roles/adm/tasks/main.yml
@@ -39,3 +39,17 @@
 
 - name: sudoers.d/adm
   template: src=sudoers dest=/etc/sudoers.d/adm owner=root group=root mode=0440 validate='visudo -cf %s'
+
+- name: lockdown access to ssh
+  lineinfile: dest=/etc/ssh/sshd_config
+              regexp="^PasswordAuthentication"
+              line="PasswordAuthentication no"
+              state=present
+  notify: restart ssh
+
+- name: do not allow root to login via ssh
+  lineinfile: dest=/etc/ssh/sshd_config
+              regexp="^PermitRootLogin"
+              line="PermitRootLogin no"
+              state=present
+  notify: restart ssh


### PR DESCRIPTION
This diff disabeles password-based-authentication for SSH. as
well as the possibility of logging in directly as root.

While there, add to .gitignore annoying files on macOS as
well as the location where I saved the virtualevn (in many
cases I've seen virtualevens called like this, so I'd argue
this is not surprising at all).

Based on: https://ryaneschinger.com/blog/securing-a-server-with-ansible/