### PR TITLE
Use explicit list of alert recipients instead of team@ or admin@

### DIFF
--- a/ansible/roles/alertmanager/templates/alertmanager.yml.j2
+++ b/ansible/roles/alertmanager/templates/alertmanager.yml.j2
@@ -51,7 +51,13 @@ inhibit_rules:
 receivers:
 - name: 'team-all'
   email_configs:
-  - to: 'team@openobservatory.org'
+  - to: 'arturo@openobservatory.org'
+    send_resolved: true
+  - to: 'leon+oonialert@darkk.net.ru' # AKA leonid@openobservatory.org
+    send_resolved: true
+  - to: 'simone@openobservatory.org'
+    send_resolved: true
+  - to: 'vasilis@openobservatory.org'
     send_resolved: true
   slack_configs:
   - send_resolved: true


### PR DESCRIPTION
We have no transparent rule to configure email aliases, so it's better to be safe and use flattened list instead of admin@ in systems allowing explicit list of addresses.

I don't think that x4 increase of Amazon SES bill matters. That's still dozens of emails, not thousands.

CC: @bassosimone, @hellais, @anadahz 